### PR TITLE
delay after UDP broadcast, fix unsuccessful broadcasting

### DIFF
--- a/ndrop/dukto.py
+++ b/ndrop/dukto.py
@@ -382,6 +382,7 @@ class DuktoServer(Transport):
         except Exception as err:
             if err.errno != 101:
                 logger.error('[Dukto]send to "%s" error: %s' % (broadcast, err))
+        logger.info('Delay {}s after UDP broadcast'.format(self.delay_after_udp_broadcast))
         time.sleep(self.delay_after_udp_broadcast)
         sock.close()
 

--- a/ndrop/dukto.py
+++ b/ndrop/dukto.py
@@ -396,6 +396,8 @@ class DuktoServer(Transport):
                 sock.sendto(data, dest)
             except Exception as err:
                 logger.error('[Dukto]send to "%s" error: %s' % (dest, err))
+            logger.info('Delay {}s after UDP unicast to {}:{}'.format(self.delay_after_udp_broadcast, *dest))
+            time.sleep(self.delay_after_udp_broadcast)
             sock.close()
 
     def loop_say_hello(self):

--- a/ndrop/dukto.py
+++ b/ndrop/dukto.py
@@ -382,7 +382,7 @@ class DuktoServer(Transport):
         except Exception as err:
             if err.errno != 101:
                 logger.error('[Dukto]send to "%s" error: %s' % (broadcast, err))
-        logger.info('Delay {}s after UDP broadcast'.format(self.delay_after_udp_broadcast))
+        logger.debug('Delay {}s after UDP broadcast'.format(self.delay_after_udp_broadcast))
         time.sleep(self.delay_after_udp_broadcast)
         sock.close()
 
@@ -397,7 +397,7 @@ class DuktoServer(Transport):
                 sock.sendto(data, dest)
             except Exception as err:
                 logger.error('[Dukto]send to "%s" error: %s' % (dest, err))
-            logger.info('Delay {}s after UDP unicast to {}:{}'.format(self.delay_after_udp_broadcast, *dest))
+            logger.debug('Delay {}s after UDP unicast to {}:{}'.format(self.delay_after_udp_broadcast, *dest))
             time.sleep(self.delay_after_udp_broadcast)
             sock.close()
 

--- a/ndrop/dukto.py
+++ b/ndrop/dukto.py
@@ -288,7 +288,7 @@ class DuktoServer(Transport):
     _node = None
     _nodes = None
     _loop_hello = True
-    _delay_after_udp_broadcast = 3
+    delay_after_udp_broadcast = 3
 
     def __init__(self, owner, addr, ssl_ck=None):
         if ssl_ck:
@@ -334,7 +334,7 @@ class DuktoServer(Transport):
         ).start()
 
         logger.info('My Node: %s' % self.format_node())
-        if len(self._ip_addrs) > 1:
+        if self._tcp_server.server_address[0] == '0.0.0.0':
             logger.info('[Dukto] listen on %s:%s(tcp):%s(udp) - bind on %s' % (
                 self._tcp_server.server_address[0], self._tcp_server.server_address[1],
                 self._udp_server.server_address[1],
@@ -382,7 +382,7 @@ class DuktoServer(Transport):
         except Exception as err:
             if err.errno != 101:
                 logger.error('[Dukto]send to "%s" error: %s' % (broadcast, err))
-        time.sleep(self._delay_after_udp_broadcast)
+        time.sleep(self.delay_after_udp_broadcast)
         sock.close()
 
     def say_hello(self, dest):

--- a/ndrop/dukto.py
+++ b/ndrop/dukto.py
@@ -288,6 +288,7 @@ class DuktoServer(Transport):
     _node = None
     _nodes = None
     _loop_hello = True
+    _delay_after_udp_broadcast = 3
 
     def __init__(self, owner, addr, ssl_ck=None):
         if ssl_ck:
@@ -333,7 +334,7 @@ class DuktoServer(Transport):
         ).start()
 
         logger.info('My Node: %s' % self.format_node())
-        if self._tcp_server.server_address[0] == '0.0.0.0':
+        if len(self._ip_addrs) > 1:
             logger.info('[Dukto] listen on %s:%s(tcp):%s(udp) - bind on %s' % (
                 self._tcp_server.server_address[0], self._tcp_server.server_address[1],
                 self._udp_server.server_address[1],
@@ -381,7 +382,7 @@ class DuktoServer(Transport):
         except Exception as err:
             if err.errno != 101:
                 logger.error('[Dukto]send to "%s" error: %s' % (broadcast, err))
-
+        time.sleep(self._delay_after_udp_broadcast)
         sock.close()
 
     def say_hello(self, dest):


### PR DESCRIPTION
All started in #3

My case is not very common, nor very rare. At first I thought ndrop didn't implement auto-discovery, I was definitely wrong. The maintainer though it was caused by firewall settings or incorrect network settings e.g. invalid broadcast address, also a wrong guess, which is.

What happened on my laptop seems like the `socket` became closable before it had sent all data out, so it's closed before the broadcast packet was sent, which might be caused by the network interface (or shall we call it "network adapter" in Windows OS), which derived from either, the hardware, or the device driver, or, some software-based virtual network adapters if the listening ip address is `0.0.0.0` (in my case, there are Zerotier Virutal LAN Adapter and Virtualbox VM Host-only Adapter involved). Anyway the reason is very low-leveled, complicated, and paticular.

So a simple `time.sleep()` solution is chosen. Although it will delay the quit process, it's 3 sec by default thankfully, and it's an variable attribute.